### PR TITLE
[codex] Make table enum edits searchable

### DIFF
--- a/packages/plugin-sdk/src/components/TableView/cells/EnumEditCell.test.tsx
+++ b/packages/plugin-sdk/src/components/TableView/cells/EnumEditCell.test.tsx
@@ -1,0 +1,36 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, within } from "../../../test/utils/test-utils";
+
+import { EnumEditCell } from "./EnumEditCell";
+
+import "@testing-library/jest-dom";
+
+describe("EnumEditCell", () => {
+  it("allows searching enum options while editing a table cell", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EnumEditCell
+        column={{
+          type: "enum",
+          options: ["Assembler", "Conveyor", "Mining drill"],
+        }}
+        value=""
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "con");
+
+    expect(input).toHaveValue("con");
+
+    const listbox = screen.getByRole("listbox");
+    expect(within(listbox).getByText("Conveyor")).toBeInTheDocument();
+    expect(within(listbox).queryByText("Assembler")).not.toBeInTheDocument();
+    expect(within(listbox).queryByText("Mining drill")).not.toBeInTheDocument();
+  });
+});

--- a/packages/plugin-sdk/src/components/TableView/cells/EnumEditCell.tsx
+++ b/packages/plugin-sdk/src/components/TableView/cells/EnumEditCell.tsx
@@ -34,7 +34,8 @@ export const EnumEditCell: React.FC<EnumEditCellProps> = ({
         if (e.key === "Enter") e.preventDefault();
       }}
       autoFocus
-      searchable={false}
+      searchable
+      nothingFoundMessage="No options found"
       allowDeselect={false}
       withCheckIcon={false}
       defaultDropdownOpened={true}


### PR DESCRIPTION
## Summary

- Enable Mantine Select search in the TableView enum edit cell.
- Add a regression test that types into the enum edit field and verifies the option list is filtered.

## Impact

Enum fields edited from the table view now support the same searchable dropdown workflow users already have in foreign-key fields, without hardcoding any schema-specific enum shape.

## Validation

- `pnpm --filter @moorestech/mooreseditor-plugin-sdk test -- src/components/TableView/cells/EnumEditCell.test.tsx`
- `pnpm run lint`
- `pnpm run build`
- `pnpm --filter @mooreseditor/mooreseditor run tauri:build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enum dropdown cells in tables now support searching to quickly find options.
  * Displays helpful message when no options match your search.

* **Tests**
  * Added test coverage for enum cell search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->